### PR TITLE
Latest MySQL docker container support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD='yes'
       - MYSQL_ROOT_HOST=%
       - MYSQL_DATABASE=dummy_development
-      - MYSQL_USER=root
     expose:
       - '3306'
     ports:


### PR DESCRIPTION
The latest MySQL docker container doesn't like the env values passed to it. Reproduction steps on a fresh install (may need to remove the database volume on existing installs):

After booting up, note that MySQL server is not running, check the logs:
```bash
docker-compose logs | grep database_1
```

See the following
```
Attaching to slacker-rails-playground_app_1, slacker-rails-playground_database_1
database_1  | 2021-04-12 03:23:45+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.33-1debian10 started.
database_1  | 2021-04-12 03:23:45+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
database_1  | 2021-04-12 03:23:45+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.33-1debian10 started.
database_1  | 2021-04-12 03:23:45+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
database_1  |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
database_1  |     - MYSQL_ROOT_PASSWORD
database_1  |     - MYSQL_ALLOW_EMPTY_PASSWORD
database_1  |     - MYSQL_RANDOM_ROOT_PASSWORD
```

The last 4 lines indicate `MYSQL_USER="root"` and `MYSQL_ALLOW_EMPTY_PASSWORD='yes'` are redundant, so removing that line.